### PR TITLE
Update outdated guidelines about errors

### DIFF
--- a/content/code/go.md
+++ b/content/code/go.md
@@ -162,9 +162,8 @@ const (
 There are various options for declaring errors:
 
 * [errors.New] for errors with simple static strings
-* [fmt.Errorf] for formatted error strings
-* Custom types that implement an `Error()` method
-* Wrapped errors using ["pkg/errors".Wrap]
+* [fmt.Errorf] for formatted and wrapped error strings
+* Custom types that implement the error interface
 
 When returning errors, consider the following to determine the best choice:
 
@@ -273,8 +272,9 @@ func open(file string) error {
 func use() {
   err := open("testfile.txt")
   if err != nil {
-    if _, ok := err.(errNotFound); ok {
-      // handle
+    var errNF *errNotFound
+    if errors.As(err, &errNF) {
+      // handle the error. errNF contains the error's value.
     } else {
       panic("unknown error")
     }
@@ -299,8 +299,8 @@ func (e errNotFound) Error() string {
   return fmt.Sprintf("file %q not found", e.file)
 }
 
-func IsNotFoundError(err error) bool {
-  _, ok := err.(errNotFound)
+func Is(tgt error) bool {
+  _, ok := tgt.(errNotFound)
   return ok
 }
 
@@ -325,14 +325,12 @@ if err != nil {
 There are three main options for propagating errors if a call fails:
 
 * Return the original error if there is no additional context to add and you want to maintain the original error type.
-* Add context using ["pkg/errors".Wrap] so that the error message provides more context and ["pkg/errors".Cause] can be used to extract the original error.
-* Use [fmt.Errorf] if the callers do not need to detect or handle that specific error case.
+* Add context using [fmt.Errorf] with the `%w` flag, so that the error message provides more context.
 
 It is recommended to add context where possible so that instead of a vague error such as "connection refused", you get more useful errors such as "call service foo: connection refused".
 
 See also [Don't just check errors, handle them gracefully].
 
-["pkg/errors".Cause]: https://godoc.org/github.com/pkg/errors#Cause
 [Don't just check errors, handle them gracefully]: https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully
 
 ### Handle Type Assertion Failures

--- a/content/code/go.md
+++ b/content/code/go.md
@@ -285,41 +285,6 @@ func use() {
 </td></tr>
 </tbody></table>
 
-Be careful with exporting custom error types directly since they become part of the public API of the package.
-It is preferable to expose matcher functions to check the error instead.
-
-```go
-// package foo
-
-type errNotFound struct {
-  file string
-}
-
-func (e errNotFound) Error() string {
-  return fmt.Sprintf("file %q not found", e.file)
-}
-
-func Is(tgt error) bool {
-  _, ok := tgt.(errNotFound)
-  return ok
-}
-
-func Open(file string) error {
-  return errNotFound{file: file}
-}
-
-// package bar
-
-err := foo.Open("foo")
-if err != nil {
-  if foo.IsNotFoundError(err) {
-    // handle
-  } else {
-    panic("unknown error")
-  }
-}
-```
-
 ### Error Wrapping
 
 There are three main options for propagating errors if a call fails:


### PR DESCRIPTION
## Goal of this PR

This PR removes outdated/wrong statements in the Go style guide. My bad, I wasn't very thorough when double-checking everything and some outdated stuff from the original style guide (which is quite old) slipped through.

It should be alright now, but there might still be more little such things to fix, so don't hesitate to let me know if you see something wrong, or even to open a PR yourself if you feel like it :)