### PR TITLE
Fix builds by locking dependency to version before breaking change

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -175,3 +175,8 @@ prs
 linter
 protobuf
 precompiled
+Blockmania
+Chainspace
+SafetyScore
+Kairos
+

--- a/content/flare/architecture.md
+++ b/content/flare/architecture.md
@@ -8,7 +8,7 @@ In addition, it contains some information regarding the Avalanche platform since
 Avalanche is an open-source platform for launching decentralized applications and enterprise blockchain deployments in one interoperable, highly scalable ecosystem.
 It is a platform with a new approach to scaling that allows for fast finality of transactions and the ability to run Solidity out-of-the-box.
 
-The most significant difference between Avalanche and other decentralized networks is the [consensus protocol](./flare.md).
+The most significant difference between Avalanche and other decentralized networks is the [consensus protocol](./consensus.md).
 The Avalanche protocol employs a novel approach to a consensus to achieve strong safety guarantees, quick finality, and high throughput without compromising decentralization.
 
 The purpose of the Avalanche platform:

--- a/content/flare/consensus.md
+++ b/content/flare/consensus.md
@@ -328,7 +328,7 @@ A non-faulty process executing a Total ordering algorithm does not advance a mes
 Thus, a non-faulty process does not advance to the total order any message in a cycle, or any message that follows a message in a cycle.
 If a Byzantine process ever participates in a cycle, then none of its subsequent messages will be ordered.
 
-A Byzantine process can originate two or more concurrent messages with the same header, but with different contents and/or acknowledgments, neither of which follows the other and possibly each of which purports to follow different messages.
+A Byzantine process can originate two or more concurrent messages with the same header, but with different contents and/or acknowledgements, neither of which follows the other and possibly each of which purports to follow different messages.
 These messages are called _mutants_.
 
 The input to the Total Ordering algorithms is a Byzantine partial order of messages and the output is a total order of messages.
@@ -353,7 +353,7 @@ Even though the messages can be delayed or lost, every non-faulty process must d
 An _execution step_ consists of adding one message to the Byzantine casual (partial) order prefix and executing the ordering algorithms.
 In a step, all candidate sets that can be constructed from the candidate messages in the casual order prefix are considered.
 
-Examples and further specifications of [Total Ordering algorithms](https://core.ac.uk/display/82213948) specify conditions for each one of these algorithms and and include calculations on their communication complexity and performance.
+Examples and further specifications of [Total Ordering algorithms](https://core.ac.uk/display/82213948) specify conditions for each one of these algorithms and include calculations on their communication complexity and performance.
 
 The algorithms employ a multistage voting strategy to achieve agreements on the total order and exploits the random structure of the casual order to achieve probabilistic termination.
 They ensure that non-faulty processes construct identical total orders on messages and that non-Byzantine processes construct consistent total orders, provided that the resilience requirements are satisfied.
@@ -473,7 +473,7 @@ It is basically a digital tracing algorithm that can be used for all kinds of ap
 It is Byzantine Fault tolerant, permissionless consensus that aims to produce a global consistent totally-ordered log of records, which is the finalized blockchain state at any time.
 Network can tolerate up to `f` faulty nodes for total number of network participants `2f+1`.
 
-The database is a distributed ledger without a center of control.
+The database is a distributed ledger.
 Each node generates its own sequence of blocks and all nodes collectively write history to a DAG structure that acts as an underlying representation of a distributed ledger current state.
 
 Nodes that can validate blocks published on the distributed ledger are known as validator nodes.

--- a/content/flow/cadence.md
+++ b/content/flow/cadence.md
@@ -835,7 +835,7 @@ If any transaction that results in account's storage use greater that the storag
 
 ### FlowClusterQC
 
-This contract manages the process of collecting votes for the root [Quorum Certificate (QC)](glossary.md#quorum-certificate) of the upcoming epoch for all Collection node clusters assigned for the next epoch.
+This contract manages the process of collecting votes for the root [Quorum Certificate (QC)](../general/glossary.md#quorum-certificate) of the upcoming epoch for all Collection node clusters assigned for the next epoch.
 During the setup phase of the epoch, collection nodes in a specific cluster generate a root block for the cluster.
 The nodes then need to submit a vote for the root block.
 Once enough cluster nodes have voted with the same unique vote, the cluster is considered complete.

--- a/content/flow/virtual-machine.md
+++ b/content/flow/virtual-machine.md
@@ -10,14 +10,14 @@ In Flow, the ledger implementation provides a number of functionalities and guar
 It is also a stateful key/value storage, and every update to the ledger creates a new state.
 A limited number of recent states is kept, and updates can be applied to any one of those states.
 
-Each ledger register is referenced by an ID - the *key* and holds a *value* - binary data.
+Each ledger register is referenced by an ID — the _key_ and holds a _value_ — binary data.
 
 ### Register ID to Ledger Path
 
-When referencing storage locations from Flow code, each register is uniquely identified by three components - *owner*, *controller* and *key*.
+When referencing storage locations from Flow code, each register is uniquely identified by three components — _owner_, _controller_ and _key_.
 Owner represents the account to which the register belongs to.
-Depending on the register, the *controller* field can be either empty or have the value of the *owner* field.
-The *key* field represents the specific storage location of the account.
+Depending on the register, the _controller_ field can be either empty or have the value of the _owner_ field.
+The _key_ field represents the specific storage location of the account.
 
 Definition of a register ID ([source](https://github.com/onflow/flow-go/blob/master/model/flow/ledger.go)):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-markdownextradata-plugin==0.2.4
 mkdocs-material==7.3.6
 markdown-include==0.6.0
 mkdocs-exclude==1.0.2
+markupsafe==2.0.1


### PR DESCRIPTION
## Goal of this PR

Fixes #28 

Also fixes two links that were broken previously:

```
WARNING  -  Documentation file 'flare/architecture.md' contains a link to 'flare/flare.md' which is not found in the documentation files.
WARNING  -  Documentation file 'flow/cadence.md' contains a link to 'flow/glossary.md' which is not found in the documentation files.
```